### PR TITLE
fix!: Push to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1
+
+
 ## [1.7.0](https://github.com/GlobalHive/vuejs-tour/compare/v1.6.1...v1.7.0) (2024-07-05)
 
 


### PR DESCRIPTION
Pushing project to 2.0.1, BREAKING CHANGE: Removed plugin approach, using component import now (See Docs)